### PR TITLE
fix: doctype of View::render violates contract

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -81,7 +81,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * Get the string contents of the view.
      *
      * @param  callable|null  $callback
-     * @return array|string
+     * @return string
      *
      * @throws \Throwable
      */


### PR DESCRIPTION
The Illuminate\View\View class is implementing the Illuminate\Contracts\View\View contract which extends the Illuminate\Contracts\Support\Renderable contract. The renderable contract is ensuring a contract for the render method always return a string:
```php
    /**
     * Get the evaluated contents of the object.
     *
     * @return string
     */
    public function render();
```

But the View class implementing the contract is specifying a return type violating the contract:
```php
/**
     * Get the string contents of the view.
     *
     * @param  callable|null  $callback
     * @return array|string
     *
     * @throws \Throwable
     */
    public function render(callable $callback = null) {}
```

The currently wrong doctype for the View::render() method throws invalid PHPStan errors.